### PR TITLE
Fix: Header in last step

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,7 +24,7 @@ export default function Header() {
     '/search',
     '/table',
     '/personal-data',
-    '/reservation-approval',
+    '/reservation-details',
   ];
 
   useEffect(() => {


### PR DESCRIPTION
Das ist wohl bei der pr zur detail page kautt gegangen und nich aufgefallen.
Ist jetzt gefixt, siehe: https://fix-header-last-step.reservation-bear.pages.dev/reservation-details/blabla